### PR TITLE
Fix backend imports and TypeScript config

### DIFF
--- a/chemfetch-backend-claude/server/routes/ocrProxy.ts
+++ b/chemfetch-backend-claude/server/routes/ocrProxy.ts
@@ -16,7 +16,6 @@ const proxyOptions: Options = {
   target: OCR_SERVICE_URL,
   changeOrigin: true,
   pathRewrite: () => '/ocr', // always forward as /ocr
-  logLevel: 'debug', // Properly typed with Options interface
 
   onProxyReq: (proxyReq, req, res) => {
     console.log(

--- a/chemfetch-backend-claude/server/utils/app.ts
+++ b/chemfetch-backend-claude/server/utils/app.ts
@@ -4,15 +4,15 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import rateLimit from 'express-rate-limit';
 import pinoHttp from 'pino-http';
-import sdsByNameRoute from './routes/sdsByName';
+import sdsByNameRoute from '../routes/sdsByName';
 
-import logger from './utils/logger';
+import logger from './logger';
 
-import scanRoute from './routes/scan';
-import confirmRoute from './routes/confirm';
-import healthRoute from './routes/health';
-import ocrProxy from './routes/ocrProxy'; // <— NEW
-import verifySdsProxy from './routes/verifySds'; // <— NEW
+import scanRoute from '../routes/scan';
+import confirmRoute from '../routes/confirm';
+import healthRoute from '../routes/health';
+import ocrProxy from '../routes/ocrProxy'; // <— NEW
+import verifySdsProxy from '../routes/verifySds'; // <— NEW
 
 dotenv.config();
 

--- a/chemfetch-backend-claude/tsconfig.json
+++ b/chemfetch-backend-claude/tsconfig.json
@@ -18,8 +18,8 @@
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": false,
     "noImplicitOverride": false,
-    "types": ["node", "jest"]
+    "types": ["node"]
   },
   "include": ["**/*.js", "**/*.ts", "**/*.json"],
-  "exclude": ["node_modules", "dist", "coverage"]
+  "exclude": ["node_modules", "dist", "coverage", "tests"]
 }


### PR DESCRIPTION
## Summary
- fix import paths for backend app utilities
- remove deprecated `logLevel` option from OCR proxy middleware
- simplify TypeScript config and exclude tests from compilation

## Testing
- `npm run type-check` (fails: Argument of type 'PostgrestError' is not assignable to parameter of type 'never')
- `npm test` (fails: Jest encountered an unexpected token / SyntaxError: Identifier '__filename' has already been declared)


------
https://chatgpt.com/codex/tasks/task_e_68a5c1b5ea8c832f993827b4929bb49b